### PR TITLE
"Paste file path as file uri link" the "title" of the link is now only the file title, not the full path.

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -201,7 +201,8 @@ export default class FilePathToUri extends Plugin {
 			try
 			{
 				let url = new URL('file://' + clipboardText);
-				editor.replaceSelection(this.makeLink(clipboardText, url.href), 'around');
+				let trunc_url = /[^/]*$/.exec(clipboardText)[0];
+				editor.replaceSelection(this.makeLink(trunc_url, url.href), 'around');
 			} catch (e)
 			{
 				return;

--- a/main.ts
+++ b/main.ts
@@ -201,7 +201,7 @@ export default class FilePathToUri extends Plugin {
 			try
 			{
 				let url = new URL('file://' + clipboardText);
-				let trunc_url = /[^/]*$/.exec(clipboardText)[0];
+				let trunc_url = /[^/]*$/.exec(clipboardText)[0]; // https://stackoverflow.com/questions/8376525/get-value-of-a-string-after-last-slash-in-javascript
 				editor.replaceSelection(this.makeLink(trunc_url, url.href), 'around');
 			} catch (e)
 			{


### PR DESCRIPTION
"Paste file path as file uri link" the "title" of the link is now only the file title, not the full path.

Instead of this 
![image](https://user-images.githubusercontent.com/20917687/169601064-f9533010-1b46-4d26-8697-eaf425635674.png)

We have this
![image](https://user-images.githubusercontent.com/20917687/169601103-b63ca1a1-3334-484f-8af3-fb1274331728.png)

Thank you for this plugin btw, it's been a real lifesaver for me!